### PR TITLE
Fix PBXGroup linting failing when version groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0 - (next version)
 
+### Fixed
+- `PBXGroup` linting failing when it referenced version groups https://github.com/xcodeswift/xclint/pull/25 by @pepibumur
+
 ### Added
 - Add Danger https://github.com/xcodeswift/xclint/pull/24 by @pepibumur
 - Formula update automation https://github.com/xcodeswift/xclint/pull/26 by @pepibumur

--- a/Sources/xclintrules/PBXGroup+ProjectLintable.swift
+++ b/Sources/xclintrules/PBXGroup+ProjectLintable.swift
@@ -18,11 +18,12 @@ extension PBXGroup: ProjectLintable {
             .flatMap { (childReference) -> LintError? in
                 let groupExists = project.groups.contains(reference: childReference)
                 let variantGroupExists = project.variantGroups.contains(reference: childReference)
+                let versionGroupExists = project.versionGroups.contains(reference: childReference)
                 let fileReferenceExists = project.fileReferences.contains(reference: childReference)
-                if groupExists || variantGroupExists || fileReferenceExists { return nil }
+                if groupExists || variantGroupExists || fileReferenceExists || versionGroupExists { return nil }
                 return LintError.missingReference(objectType: String(describing: type(of: self)),
                                                   objectReference: reference,
-                                                  missingReference: "PBXFileReference/PBXGroup/PBXVariantGroup<\(childReference)>")
+                                                  missingReference: "PBXFileReference/PBXGroup/PBXVariantGroup/PBXVersionGroup<\(childReference)>")
             }
     }
     

--- a/Tests/xclintrulesTests/PBXGroup+ProjectLintableTests.swift
+++ b/Tests/xclintrulesTests/PBXGroup+ProjectLintableTests.swift
@@ -10,7 +10,7 @@ final class PBXGroup_ProjectLintableTests: XCTestCase {
         let subject = PBXGroup(reference: "ref", children: ["child"])
         let project = PBXProj(objectVersion: 0, rootObject: "1")
         let got = subject.lint(project: project)
-        let expected = LintError.missingReference(objectType: "PBXGroup", objectReference: "ref", missingReference: "PBXFileReference/PBXGroup/PBXVariantGroup<child>")
+        let expected = LintError.missingReference(objectType: "PBXGroup", objectReference: "ref", missingReference: "PBXFileReference/PBXGroup/PBXVariantGroup/PBXVersionGroup<child>")
         XCTAssertEqual(got.first, expected)
     }
     


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xclint/issues/23

### Short description 📝
When a `PBXGroup` referenced a version group the linting failed.

### Solution 📦
Update `PBXGroup` linting to include the version groups in the list to check.

### Implementation 👩‍💻👨‍💻
- [x] Fix it!

### GIF
![gif](https://media.giphy.com/media/l3q2xgv1dIVgnGwxy/giphy.gif)
