### PR TITLE
Upgrade `xclint` to the latest `xcproj`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Added
 - Add Danger https://github.com/xcodeswift/xclint/pull/24 by @pepibumur
 - Formula update automation https://github.com/xcodeswift/xclint/pull/26 by @pepibumur
+- Update to latest xcproj version (1.7.0) https://github.com/xcodeswift/xclint/pull/28 by @rahul-malik
 
 ## 0.1.0
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "2981eccd86a69ea12a7f71a4c6b4d5177c2972a9",
-          "version": "4.1.0"
+          "revision": "09f27784d9e328670ef0a181c832cce497117131",
+          "version": "4.2.2"
         }
       },
       {
@@ -33,8 +33,17 @@
         "repositoryURL": "https://github.com/onevcat/Rainbow",
         "state": {
           "branch": null,
-          "revision": "dfe579abc72347618e0ffde4faa36fa085c5f3bc",
-          "version": "3.0.0"
+          "revision": "f407235c7e473c3cb2d2907bb6822616d22a0b78",
+          "version": "3.0.3"
+        }
+      },
+      {
+        "package": "ShellOut",
+        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
+        "state": {
+          "branch": null,
+          "revision": "479a89d9bfa7585496bd4a3e4faffac5b01af37f",
+          "version": "2.0.0"
         }
       },
       {
@@ -51,8 +60,8 @@
         "repositoryURL": "https://github.com/xcodeswift/xcproj.git",
         "state": {
           "branch": null,
-          "revision": "35ca8f3ef8c1c237e794100da466d656582e1587",
-          "version": "1.3.0"
+          "revision": "e0162b018e62b824a3c8af52f44af77f974b6ab2",
+          "version": "1.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     dependencies: [
       .package(url: "https://github.com/kylef/Commander.git", .upToNextMinor(from: "0.6.0")),
       .package(url: "https://github.com/kylef/PathKit.git", .upToNextMinor(from: "0.8.0")),
-      .package(url: "https://github.com/xcodeswift/xcproj.git", .upToNextMinor(from: "1.3.0")),
+      .package(url: "https://github.com/xcodeswift/xcproj.git", .upToNextMinor(from: "1.7.0")),
       .package(url: "https://github.com/onevcat/Rainbow", .upToNextMinor(from: "3.0.0"))
     ],
     targets: [

--- a/Sources/xclintrules/XcodeProj+Lintable.swift
+++ b/Sources/xclintrules/XcodeProj+Lintable.swift
@@ -6,30 +6,15 @@ extension XcodeProj: Lintable {
     
     public func lint() -> [LintError] {
         var errors: [LintError] = []
-        errors.append(contentsOf: lintDuplicates())
-        errors.append(contentsOf: pbxproj.buildFiles.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.aggregateTargets.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.nativeTargets.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.containerItemProxies.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.groups.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.configurationLists.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.variantGroups.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.targetDependencies.flatMap({ $0.lint(project: pbxproj) }))
-        errors.append(contentsOf: pbxproj.projects.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.buildFiles.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.aggregateTargets.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.nativeTargets.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.containerItemProxies.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.groups.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.configurationLists.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.variantGroups.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.targetDependencies.values.flatMap({ $0.lint(project: pbxproj) }))
+        errors.append(contentsOf: pbxproj.objects.projects.values.flatMap({ $0.lint(project: pbxproj) }))
         return errors
     }
-    
-    // MARK: - Fileprivate
-    
-    fileprivate func lintDuplicates() -> [LintError] {
-        // FIXME: When the .pbxproj is parsed duplicated entries are automatically removed.
-        // As a result this lint has no effect.
-        return pbxproj.objects
-            .reduce(into: [String: [PBXObject]](), { $0[$1.reference, default: []].append($1) })
-            .filter({ $0.value.count != 1 })
-            .map { (reference, _) -> LintError in
-                return LintError.duplicatedReference(reference: reference)
-            }
-    }
-    
 }


### PR DESCRIPTION
### Short description 📝
This PR updates `xclint` to the latest release of `xcproj`. This is necessary because as we add new element types to `xcproj`, `xclint` will not understand these types until it is upgraded.

### Solution 📦
Upgraded `Package.swift` reference for `xcproj` to `1.7.0`

### Implementation 👩‍💻👨‍💻
- [x] Update Swift package manifest to point to xcproj 1.7.0

### GIF
![gif](https://media.giphy.com/media/3otPoIRRO0TlyZAuT6/giphy.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xclint/28)
<!-- Reviewable:end -->
